### PR TITLE
Confusion matrix code wouldn't run if one input had only one factor value present

### DIFF
--- a/R/confusion_matrix.R
+++ b/R/confusion_matrix.R
@@ -91,10 +91,14 @@ confusion_matrix.default <- function(x, y, positive = NULL, boot = FALSE, boot_s
   xname <- deparse(cl$x)
   yname <- deparse(cl$y)
 
-  x <- factor(x)  # Truth
-  y <- factor(y)  # Predicited
+  if (!is.factor(x)) {
+    x <- factor(x)  # Truth
+  }
+  if (!is.factor(y)) {
+    y <- factor(y)  # Predicted
+  }
 
-  if (nlevels(x) != 2L || nlevels(x) != 2L) {
+  if (nlevels(x) != 2L || nlevels(y) != 2L) {
     stop(paste0("qwraps2::confusion_matrix only supports inputs with two unique values.",
                 "\n  `", xname, "` has ", nlevels(x), " unique values and \n  `",
                 yname, "` has ", nlevels(y), " unique values."),


### PR DESCRIPTION
In running the `confusion_matrix` on my naive model (my model predicts one class only), I discovered a couple of bugs. Specifically:

* If user passes in a factor with 2 levels, but only instances of one of the factors, confusion matrix code converts the factor to a factor which causes one of the levels to be lost
* Check for factor levels only checked x (but did it twice!)

While other checks might be beneficial, or the factor conversion improved, the attached pull request allows users to pass in a factor with the correct levels set and get a confusion matrix and summary statistics output.

Here's two example cases:

An example that works with the pull request: If the user provides factors that have manually been configured to have the same levels with the same labels, the `confusion_matrix()` call will now work:

```r
pred <- factor(c(0,0,0,0,0,0,0,0,0,0,0,0,0,0), levels=c(0,1), labels=c(0, 1))
refs <- factor( c(1,0,1,0,1,0,0,0,0,0,0,0,0,1), levels=c(0,1), labels=c(0, 1))

qwraps2::confusion_matrix(x = pred, y=refs)
```

An example that requires user to preconvert to a factor: In this, a vector is passed into `confusion_matrix` and is automatically converted to a factor. Since `pred` is only comprised of 1 value, the `factor()` call results in a factor of 1 level:

```r
pred <- c(0,0,0,0,0,0,0,0,0,0,0,0,0,0)
refs <- c(1,0,1,0,1,0,0,0,0,0,0,0,0,1)

qwraps2::confusion_matrix(x = pred, y=refs)
# resulting output:
#Error: qwraps2::confusion_matrix only supports inputs with two unique values.
#  `pred` has 1 unique values and
#  `refs` has 2 unique values.
```
